### PR TITLE
Adding NetSupport

### DIFF
--- a/rmm.yml
+++ b/rmm.yml
@@ -169,7 +169,11 @@ RMMs:
         - presentationhost.exe
         - remcmdstub.exe
       MacOS:
+        - NetSupportDNA/SystemAgent/NetSupport*.pkg # pulled from NetSupport documentation
+        - NetSupport*.pkg # pulled from NetSupport documentation
       Linux:
+        - nsm/support # pulled from NetSupport documentation
+        - support # pulled from NetSupport documentation
     NetConn:
       Domains: # note, self hosted versions exist, unreliable
       Ports:

--- a/rmm.yml
+++ b/rmm.yml
@@ -161,3 +161,16 @@ RMMs:
         - 21117
         - 21118
         - 21119
+  NetSupport: # note most information pulled from https://thedfirreport.com/2023/10/30/netsupport-intrusion-results-in-domain-compromise/
+    Executables:
+      SignerSubjectName:
+      MacOSSigner:
+      Windows:
+        - presentationhost.exe
+        - remcmdstub.exe
+      MacOS:
+      Linux:
+    NetConn:
+      Domains: # note, self hosted versions exist, unreliable
+      Ports:
+        - 443


### PR DESCRIPTION
NetSupport is one of the oldest RMM tools out there. It is included in multiple RATs as well as recently in a breach investigated by DFIR Report. Article found here https://thedfirreport.com/2023/10/30/netsupport-intrusion-results-in-domain-compromise/

The MacOS and Linux parts were found through the documentation on their site. 